### PR TITLE
Fixes ClassNotFound exception from incompatible transitive dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,5 +2,5 @@
   :description "Clojure client for PubNub"
   :dependencies [[clj-http "0.4.3"]
                  [cheshire "4.0.0"]
-                 [digest "1.4.2"]]
+                 [digest "1.4.0"]]
   :dev-dependencies [[swank-clojure "1.4.2"]])

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(defproject clj-pubnub "0.0.1"
+(defproject clj-pubnub "0.0.2"
   :description "Clojure client for PubNub"
-  :dependencies [[clj-http "0.3.2"]
-                 [cheshire "2.2.2"]
-                 [digest "1.4.0"]]
-  :dev-dependencies [[swank-clojure "1.4.0"]])
+  :dependencies [[clj-http "0.4.3"]
+                 [cheshire "4.0.0"]
+                 [digest "1.4.2"]]
+  :dev-dependencies [[swank-clojure "1.4.2"]])

--- a/src/clj_pubnub/client.clj
+++ b/src/clj_pubnub/client.clj
@@ -2,7 +2,7 @@
   (:use [digest :only [digest]])
   (:require [clj-http.client :as http]
             [cheshire.core :as json]
-            [clojure.contrib.string :as str]))
+            [clojure.string :as str]))
 
 (defonce ^{:dynamic true} config
   {})


### PR DESCRIPTION
- Upgraded dependencies for Clojure 1.4.0
- Changed clojure.contrib.string to clojure.string in client.clj
- Bumped version to 0.0.2
